### PR TITLE
Allow multiple extensions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,9 +62,9 @@ are optional.
     interpreted as relative to the application root, next to the ``static`` and
     ``templates`` directories. Defaults to ``pages``.
 
-``FLATPAGES_EXTENSION``
-    Filename extension for pages. Files in the ``FLATPAGES_ROOT`` directory
-    without this suffix are ignored. Defaults to ``.html``.
+``FLATPAGES_EXTENSIONS``
+    Filename extensions for pages. Files in the ``FLATPAGES_ROOT`` directory
+    without one of these this suffixes are ignored. Defaults to ``.html``.
 
 ``FLATPAGES_ENCODING``
     Encoding of the pages files. Defaults to ``utf8``.
@@ -114,8 +114,8 @@ How it works
 
 When first needed (see :ref:`laziness-and-caching` for more about this),
 the extension loads all pages from the filesystem: a :class:`Page` object is
-created for all files in ``FLATPAGES_ROOT`` whose name ends with
-``FLATPAGES_EXTENSION``.
+created for all files in ``FLATPAGES_ROOT`` whose name ends with one of
+``FLATPAGES_EXTENSIONS``.
 
 Each of these objects is associated to a path:
 the slash-separated (whatever the OS) name of the file it was loaded from,

--- a/flask_flatpages/flatpages.py
+++ b/flask_flatpages/flatpages.py
@@ -154,7 +154,7 @@ class FlatPages(object):
         if auto:
             self.reload()
 
-    def _load_file(self, path, filename):
+    def _load_file(self, path, filename, extension):
         """Load file from file system and put it to cached dict as
         :class:`Path` and `mtime` tuple.
         """
@@ -173,7 +173,7 @@ class FlatPages(object):
                 with open(filename) as handler:
                     content = handler.read().decode(encoding)
 
-            page = self._parse(content, path)
+            page = self._parse(content, path, extension)
             self._file_cache[filename] = (page, mtime)
 
         return page
@@ -203,14 +203,15 @@ class FlatPages(object):
                 elif extension is not None:
                     name_without_extension = name[:-len(extension)]
                     path = u'/'.join(path_prefix + (name_without_extension, ))
-                    pages[path] = self._load_file(path, full_name)
+                    pages[path] = self._load_file(path, full_name,
+                                                  extension=extension)
 
         pages = {}
 
         _walk(self.root)
         return pages
 
-    def _parse(self, content, path):
+    def _parse(self, content, path, extension):
         """Parse a flatpage file, i.e. read and parse its meta data and body.
 
         :return: initialized :class:`Page` instance.
@@ -234,7 +235,7 @@ class FlatPages(object):
         html_renderer = self._smart_html_renderer(html_renderer)
 
         # Initialize and return Page instance
-        return Page(path, meta, content, html_renderer)
+        return Page(path, meta, content, html_renderer, extension=extension)
 
     def _smart_html_renderer(self, html_renderer):
         """This wraps the rendering function in order to allow the use of

--- a/flask_flatpages/page.py
+++ b/flask_flatpages/page.py
@@ -18,7 +18,7 @@ class Page(object):
     Main purpose is to render the page's content with a ``html_renderer``
     function.
     """
-    def __init__(self, path, meta, body, html_renderer):
+    def __init__(self, path, meta, body, html_renderer, extension=None):
         """
         Initialize Page instance.
 
@@ -26,6 +26,7 @@ class Page(object):
         :param meta: Page meta data in YAML format.
         :param body: Page body.
         :param html_renderer: HTML renderer function.
+        :param extension: File extension.
         """
         #: Path this page was obtained from, as in ``pages.get(path)``
         self.path = path
@@ -34,6 +35,8 @@ class Page(object):
         self.body = body
         #: Renderer function
         self.html_renderer = html_renderer
+        #: Extension of the source file
+        self.extension = extension
 
     def __getitem__(self, name):
         """Shortcut for accessing metadata.

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -246,6 +246,13 @@ class TestFlatPages(unittest.TestCase):
                  'foo/42/not_a_page'])
         )
 
+    def test_page_extension(self):
+        app = Flask(__name__)
+        app.config['FLATPAGES_EXTENSIONS'] = ['.html', '.txt']
+        pages = FlatPages(app)
+        self.assertEqual(pages.get('foo/bar').extension, '.html')
+        self.assertEqual(pages.get('not_a_page').extension, '.txt')
+
     def test_lazy_loading(self):
         with temp_pages() as pages:
             bar = pages.get('foo/bar')

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -222,6 +222,13 @@ class TestFlatPages(unittest.TestCase):
             set(['not_a_page', 'foo/42/not_a_page'])
         )
 
+    def test_deprecated_extension_warning(self):
+        app = Flask(__name__)
+        app.config['FLATPAGES_EXTENSION'] = '.txt'
+        app.config['DEBUG'] = True
+        pages = FlatPages()
+        self.assertRaises(DeprecationWarning, pages.init_app, app)
+
     def test_other_extension(self):
         app = Flask(__name__)
         app.config['FLATPAGES_EXTENSIONS'] = ['.txt']

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -213,13 +213,37 @@ class TestFlatPages(unittest.TestCase):
             u'<p>Text</p>'
         )
 
-    def test_other_extension(self):
+    def test_deprecated_extension(self):
         app = Flask(__name__)
         app.config['FLATPAGES_EXTENSION'] = '.txt'
         pages = FlatPages(app)
         self.assertEqual(
             set(page.path for page in pages),
             set(['not_a_page', 'foo/42/not_a_page'])
+        )
+
+    def test_other_extension(self):
+        app = Flask(__name__)
+        app.config['FLATPAGES_EXTENSIONS'] = ['.txt']
+        pages = FlatPages(app)
+        self.assertEqual(
+            set(page.path for page in pages),
+            set(['not_a_page', 'foo/42/not_a_page'])
+        )
+
+    def test_multi_extensions(self):
+        app = Flask(__name__)
+        app.config['FLATPAGES_EXTENSIONS'] = ['.html', '.txt']
+        pages = FlatPages(app)
+        self.assertEqual(
+            set(page.path for page in pages),
+            set(['foo/bar',
+                 'foo/lorem/ipsum',
+                 'foo',
+                 'headerid',
+                 'hello',
+                 'not_a_page',
+                 'foo/42/not_a_page'])
         )
 
     def test_lazy_loading(self):


### PR DESCRIPTION
This does basically two things:

-  Allow to use multiple extensions for source files (deprecate `FLATPAGES_EXTENSION` in favor of `FLATPAGES_EXTENSIONS`)
-  Store file extension in page object

This can be used with renderers that can render more than one markup language (e.g. [pandoc](johnmacfarlane.net/pandoc/)). The renderer can extract the original file extension from the page object in order to figure oout the right source markup.

I am not sure whether it is wise to mix markup languages (or worse: mix file extensions for a single markup, e.g. `.md` and `.markdown`). Still I do not see a reason why it should be impossible.