### PR TITLE
do not reinstall flask on every tox run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,60 +12,60 @@ whitelist_externals = make
 
 [testenv:py26flask08]
 basepython = python2.6
+deps = Flask==0.8
 commands =
-  pip install -q -I Flask==0.8
   make -C testapp/ test
 
 [testenv:py26flask09]
 basepython = python2.6
+deps = Flask==0.9
 commands =
-  pip install -q -I Flask==0.9
   make -C testapp/ test
 
 [testenv:py26flask010]
 basepython = python2.6
+deps = Flask==0.10.1
 commands =
-  pip install -q -I Flask==0.10.1
   make -C testapp/ test
 
 [testenv:py27flask08]
 basepython = python2.7
+deps = Flask==0.8
 commands =
-  pip install -q -I Flask==0.8
   make -C testapp/ test
 
 [testenv:py27flask09]
 basepython = python2.7
+deps = Flask==0.9
 commands =
-  pip install -q -I Flask==0.9
   make -C testapp/ test
 
 [testenv:py27flask010]
 basepython = python2.7
+deps = Flask==0.10.1
 commands =
-  pip install -q -I Flask==0.10.1
   make -C testapp/ test
 
 [testenv:py33flask010]
 basepython = python3.3
+deps = Flask==0.10.1
 commands =
-  pip install -q -I Flask==0.10.1
   make -C testapp/ test
 
 [testenv:pypyflask08]
 basepython = pypy
+deps = Flask==0.8
 commands =
-  pip install -q -I Flask==0.8
   make -C testapp/ test
 
 [testenv:pypyflask09]
 basepython = pypy
+deps = Flask==0.9
 commands =
-  pip install -q -I Flask==0.9
   make -C testapp/ test
 
 [testenv:pypyflask010]
 basepython = pypy
+deps = Flask==0.10.1
 commands =
-  pip install -q -I Flask==0.10.1
   make -C testapp/ test


### PR DESCRIPTION
Currently flask is reinstalled on every run of tox. This makes testing really slow (and therefore less fun). I did not see a reason for this, so I changed it. If there  is a reason, please understand this as a request for documentation.